### PR TITLE
bower package descriptor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "filterable",
+  "version": "0.2.1",
+    "main": ["./lib/jquery.filterable.js", "./lib/bootstrap-filterable.css"],
+    "dependencies": {
+        "bootstrap": ">=2.3.2 <3.0.0",
+        "x-editable": ">=1.4.6"
+    },
+  "homepage": "https://github.com/lightswitch05/filterable",
+  "authors": [
+    "lightswitch05 <daniel@developerdan.com>"
+  ],
+  "description": "Bootstrap themed per-column filter for an HTML table",
+  "main": ["./lib/jquery.filterable.js", "./lib/bootstrap-filterable.css"]
+  "license": "MIT"
+}


### PR DESCRIPTION
Awesome piece of work, brilliantly executed. Well done!

It would be so cool if we could install from bower. I made several attempts to create this descriptor for you and even tried a new release tag which will include the `bower.json` file but it keeps flunking out with complaints that it can't find the package.

Maybe it has to do with the urls pointing to the main repo instead of my fork in which case this may just work as expected. If not at least this issue may serve to encourage the addition of a working definition for bower.

@lightswitch05 Tx for filterable!  =)
